### PR TITLE
Replace StopServiceFailed with ServiceControlRequestFailed

### DIFF
--- a/Topshelf.Squirrel.Updater/Builders/Host.StopAndUninstall.cs
+++ b/Topshelf.Squirrel.Updater/Builders/Host.StopAndUninstall.cs
@@ -167,7 +167,7 @@ namespace Topshelf.Squirrel.Updater.Builders
 					return TopshelfExitCode.Ok;
 				}
 
-				if (exitCode == TopshelfExitCode.StopServiceFailed)
+				if (exitCode == TopshelfExitCode.ServiceControlRequestFailed)
 				{
 					Process.GetProcessById(_processId).Kill();
 					exitCode = TopshelfExitCode.Ok;


### PR DESCRIPTION
TopshelfExitCodes were changed to align more closely with Windows error codes.
Any reference to StopServiceFailed should now use ServiceControlRequestFailed.
See for details: https://github.com/Topshelf/Topshelf/pull/475
New TopshelfExitCodes: https://github.com/Topshelf/Topshelf/blob/develop/src/Topshelf/TopshelfExitCode.cs